### PR TITLE
Fix decoding of evaluation results to support multibyte characters

### DIFF
--- a/el/sclang-interp.el
+++ b/el/sclang-interp.el
@@ -444,7 +444,8 @@ Change this if \"cat\" has a non-standard name or location."
     (while (and (> (length string) 3)
 		(>= (length string)
 		    (setq end (+ 4 (sclang-string-to-int32 string)))))
-      (sclang-handle-command-result (car (read-from-string string 4 end)))
+      (sclang-handle-command-result
+       (read (string-as-multibyte (substring string 4 end))))
       (setq string (substring string end))))
   (setq sclang-command-process-previous string))
 


### PR DESCRIPTION
Symptom: (sclang-eval-sync "\"ö\"") evaluates to "Ã¶" After this patch:
(sclang-eval-sync "\"ö\"") => "ö"

This was tricky to figure out, so here is a bit of background. scel uses a
so-called command FIFO to send (amongst other things) evaluation results to
Emacs.  This FIFO uses a pascal-string (32bit string length followed by
character data) to send Lisp to Emacs.  The command process coding system is
already set to 'no-conversion on the Emacs side to avoid crippling the int32
at the beginning of every string. However, the read-from-string call in
sclang-command-process-filter implicitly converts the unibyte string received
from the process to a multibyte string, without doing proper conversion. The
right function to use here is string-as-multibyte, which does the correct
conversion.