### PR TITLE
Use cl-lib instead of obsolete cl package

### DIFF
--- a/el/sclang-mode.el
+++ b/el/sclang-mode.el
@@ -15,9 +15,9 @@
 ;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
 ;; USA
 
+(require 'cl-lib)
+
 (eval-when-compile
-  (require 'cl)
-  (load "cl-seq" nil t)
   (require 'font-lock)
   (require 'sclang-util))
 
@@ -255,7 +255,7 @@
         (let ((thing (thing-at-point 'word)))
           (if (null thing)
               (setq res nil continue nil)
-            (when (position (substring-no-properties thing) sclang-class-list :test 'equal)
+            (when (cl-position (substring-no-properties thing) sclang-class-list :test 'equal)
               (setq continue nil))))))
     res))
 
@@ -450,10 +450,7 @@ Returns the column to indent to."
     (sclang-document-edited-p . (prSetEdited (buffer-modified-p)))))
 
 (defmacro sclang-next-document-id ()
-  `(incf sclang-document-counter))
-
-(defun sclang-document-list ()
-  sclang-document-list)
+  `(cl-incf sclang-document-counter))
 
 (defun sclang-document-id (buffer)
   (cdr (assq 'sclang-document-id (buffer-local-variables buffer))))
@@ -467,15 +464,15 @@ Returns the column to indent to."
        ,@body)))
 
 (defun sclang-get-document (id)
-  (find-if (lambda (doc) (eq id (sclang-document-id doc)))
-	   (sclang-document-list)))
+  (cl-find-if (lambda (buffer) (eq id (sclang-document-id buffer)))
+	      sclang-document-list))
 
 (defun sclang-init-document ()
   (set (make-local-variable 'sclang-document-id) (sclang-next-document-id))
   (set (make-local-variable 'sclang-document-envir) nil)
   (dolist (assoc sclang-document-property-map)
     (set (make-local-variable (car assoc)) nil))
-  (pushnew (current-buffer) sclang-document-list))
+  (cl-pushnew (current-buffer) sclang-document-list))
 
 (defun sclang-document-update-property-1 (assoc &optional force)
   (when (consp assoc)
@@ -514,7 +511,7 @@ Returns the column to indent to."
     t))
 
 (defun sclang-document-library-startup-hook-function ()
-  (dolist (buffer (sclang-document-list))
+  (dolist (buffer sclang-document-list)
     (with-current-buffer buffer
       (sclang-make-document)))
   (sclang-set-current-document (current-buffer) t))

--- a/el/sclang-server.el
+++ b/el/sclang-server.el
@@ -15,15 +15,16 @@
 ;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
 ;; USA
 
+(require 'cl-lib)
+
 (eval-when-compile
-  (require 'cl)
   (require 'sclang-util)
   (require 'sclang-interp)
   (require 'sclang-language)
   (require 'sclang-mode))
 
 (defcustom sclang-server-panel "Server.default.makeWindow"
-  "*Expression to execute when `sclang-show-server-panel' is invoked."
+  "Expression to execute when `sclang-show-server-panel' is invoked."
   :group 'sclang-interface
   :type '(choice (const "Server.default.makeWindow")
 		 (const "\\SCUM.asClass.do { \\SCUM.asClass.desktop.showServerPanel }")
@@ -61,7 +62,7 @@
  '_updateServer
  (lambda (arg)
    (setq sclang-server-alist
-	 (sort (cdr arg) (lambda (a b) (string< (car a) (car b)))))
+	 (sort (cdr arg) (lambda (a b) (string-lessp (car a) (car b)))))
    (setq sclang-default-server (car arg))
    (unless sclang-current-server-initialized
      ;; only set the current server automatically once after startup
@@ -73,9 +74,9 @@
   "Select next server for display."
   (interactive)
   (sclang-set-server)
-  (let ((list (or (cdr (member-if (lambda (assoc)
-				    (eq (car assoc) sclang-current-server))
-				  sclang-server-alist))
+  (let ((list (or (cdr (cl-member-if (lambda (assoc)
+				       (eq (car assoc) sclang-current-server))
+				     sclang-server-alist))
 		  sclang-server-alist)))
     (setq sclang-current-server (car (car list))))
   (sclang-update-server-info))
@@ -99,8 +100,7 @@
      ["Quit" sclang-server-quit]
      "-"
      ["Free All" sclang-server-free-all :active (sclang-server-running-p)]
-     ["Make Default" sclang-server-make-default]
-     )))
+     ["Make Default" sclang-server-make-default])))
 
 (defun sclang-server-fill-mouse-map (map prefix)
   (define-key map (vector prefix 'mouse-1) 'sclang-mouse-next-server)

--- a/el/sclang.el
+++ b/el/sclang.el
@@ -47,9 +47,6 @@
   (customize-group 'sclang))
 
 (eval-and-compile
-  (require 'cl))
-
-(eval-and-compile
   (let ((load-path
 	 (if (and (boundp 'byte-compile-dest-file)
 		  (stringp byte-compile-dest-file))


### PR DESCRIPTION
This is actually pretty boring.  It replaces calls to obsolete aliases with
the properly namespaced functions from the cl-lib package.

This raises our minimal Emacs version requirement to 24.3 (2013-03-10). 
However, people using earlier versions can install the cl-lib package from the
Emacs package system.

While at it:
* remove function `sclang-document-list' which was really useless.
* fix `sclang-format-pseq' which needed to use `cl-labels'
  instead of `cl-flet' to actually work.
* (cl-reduce (lambda (a b) (or a b)) (mapcar function list))
  is much better written as (and now properly short-circuits):
  (cl-some function list)
* (cl-remove-if 'null list)
  should be written as
  (remq nil list)