### PR TITLE
Fix a number of overlooked obsolete aliases

### DIFF
--- a/el/sclang-interp.el
+++ b/el/sclang-interp.el
@@ -284,7 +284,7 @@ If EOB-P is non-nil, positions cursor at end of buffer."
 
 (defun sclang-make-options ()
   (let ((default-directory ""))
-    (append
+    (nconc
      (when (and sclang-runtime-directory
 		(file-directory-p sclang-runtime-directory))
        (list "-d" (expand-file-name sclang-runtime-directory)))
@@ -337,7 +337,7 @@ If EOB-P is non-nil, positions cursor at end of buffer."
 	  (i 0))
       (while (and (sclang-get-process)
 		  (< i tries))
-	(incf i)
+	(cl-incf i)
 	(sit-for 0.5))))
   (sclang-kill)
   (sclang-stop-command-process))
@@ -441,7 +441,7 @@ Change this if \"cat\" has a non-standard name or location."
 		(>= (length string)
 		    (setq end (+ 4 (sclang-string-to-int32 string)))))
       (sclang-handle-command-result
-       (read (string-as-multibyte (substring string 4 end))))
+       (read (decode-coding-string (substring string 4 end) 'utf-8)))
       (setq string (substring string end))))
   (setq sclang-command-process-previous string))
 
@@ -590,7 +590,7 @@ if PRINT-P is non-nil. Return STRING if successful, otherwise nil."
     (if (and (processp proc) (eq (process-status proc) 'run))
 	(let ((time (current-time)) (tick 10000) elt)
 	  (sclang-perform-command 'evalSCLang string time)
-	  (while (and (> (decf tick) 0)
+	  (while (and (> (cl-decf tick) 0)
 		      (not (setq elt (assoc time sclang-eval-results))))
 	    (accept-process-output proc 0 100))
 	  (if elt

--- a/el/sclang-language.el
+++ b/el/sclang-language.el
@@ -391,7 +391,7 @@ A defun may either be a class definition or a code block, see
 `sclang-beginning-of-defun-regexp'."
   (save-excursion
     (with-syntax-table sclang-mode-syntax-table
-      (multiple-value-bind (beg end) (sclang-point-in-defun-p)
+      (cl-multiple-value-bind (beg end) (sclang-point-in-defun-p)
 	(and beg end (buffer-substring-no-properties beg end))))))
 
 ;; =====================================================================

--- a/el/sclang-mode.el
+++ b/el/sclang-mode.el
@@ -535,7 +535,7 @@ Returns the column to indent to."
 (sclang-set-command-handler
  '_documentOpen
  (lambda (arg)
-   (multiple-value-bind (file-name region-start region-length) arg
+   (cl-multiple-value-bind (file-name region-start region-length) arg
      (let ((buffer (get-file-buffer file-name)))
        (unless buffer
 	 (setf buffer (find-file-noselect file-name)))
@@ -549,7 +549,7 @@ Returns the column to indent to."
 (sclang-set-command-handler
  '_documentNew
  (lambda (arg)
-   (multiple-value-bind (name str make-listener) arg
+   (cl-multiple-value-bind (name str make-listener) arg
      (let ((buffer (generate-new-buffer name)))
        (with-current-buffer buffer
 	 (insert str)
@@ -567,7 +567,7 @@ Returns the column to indent to."
 (sclang-set-command-handler
  '_documentRename
  (lambda (arg)
-   (multiple-value-bind (id name) arg
+   (cl-multiple-value-bind (id name) arg
      (when (stringp name)
        (let ((doc (and (integerp id) (sclang-get-document id))))
 	 (when doc
@@ -579,7 +579,7 @@ Returns the column to indent to."
 (sclang-set-command-handler
  '_documentSetEditable
  (lambda (arg)
-   (multiple-value-bind (id flag) arg
+   (cl-multiple-value-bind (id flag) arg
      (let ((doc (and (integerp id) (sclang-get-document id))))
        (when doc
 	 (with-current-buffer doc
@@ -597,7 +597,7 @@ Returns the column to indent to."
 (sclang-set-command-handler
  '_documentPutString
 (lambda (arg)
-   (multiple-value-bind (id str) arg
+   (cl-multiple-value-bind (id str) arg
      (let ((doc (and (integerp id) (sclang-get-document id))))
        (when doc
 	 (with-current-buffer doc

--- a/el/sclang-widgets.el
+++ b/el/sclang-widgets.el
@@ -26,6 +26,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (eval-when-compile (require 'sclang-util)
                    (require 'sclang-language))
 (eval-and-compile (require 'sclang-interp))
@@ -76,9 +77,9 @@
 (sclang-set-command-handler
  '_widgetSetStates
  (lambda (arg)
-   (multiple-value-bind (buffer id states value) arg
+   (cl-multiple-value-bind (buffer id states value) arg
      (with-current-buffer (get-buffer buffer)
-       (let ((widget (cdr (find id sclang-widgets :key 'car))))
+       (let ((widget (cdr (cl-find id sclang-widgets :key 'car))))
 	 (widget-put widget :states states)
 	 (widget-value-set widget value)
 	 value)))))


### PR DESCRIPTION
For some reason, these slipped my attention.  Sorry about that. Also:
* `nconc' is more efficient then `append' if destructive modification is not
 an issue.
* Emacs 26 actually deprecated `string-as-multibyte' in favour of
 `decode-coding-string' since the latter actually forces the user to
 specify an encoding.