### PR TITLE
Derive sclang-mode via define-derived-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  - `M-<tab>` or `C-M-i` is no longer bound to `sclang-complete-symbol`
    to make builtin completion work as expected.
+ - `sclang-mode` is now derived from `prog-mode`.

--- a/el/sclang-mode.el
+++ b/el/sclang-mode.el
@@ -671,15 +671,12 @@ Returns the column to indent to."
   :group 'sclang-mode
   :type 'hook)
 
-(defun sclang-mode ()
+;;;###autoload
+(define-derived-mode sclang-mode prog-mode "SCLang"
   "Major mode for editing SuperCollider language code.
 \\{sclang-mode-map}"
-  (interactive)
-  (kill-all-local-variables)
-  (set-syntax-table sclang-mode-syntax-table)
-  (use-local-map sclang-mode-map)
-  (setq mode-name "SCLang")
-  (setq major-mode 'sclang-mode)
+  :group 'sclang
+  :syntax-table sclang-mode-syntax-table
   (sclang-mode-set-local-variables)
   (sclang-set-font-lock-keywords)
   (sclang-init-document)
@@ -689,15 +686,14 @@ Returns the column to indent to."
   (add-hook 'completion-at-point-functions
             #'sclang-completion-at-point nil 'local)
   (when (fboundp 'company-mode)
-    (add-to-list 'company-backends 'company-capf))
-
-  (run-hooks 'sclang-mode-hook))
+    (add-to-list 'company-backends 'company-capf)))
 
 ;; =====================================================================
 ;; module initialization
 ;; =====================================================================
 
-(add-to-list 'auto-mode-alist '("\\.\\(sc\\|scd\\)$" . sclang-mode))
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.scd?\\'" . sclang-mode))
 (add-to-list 'interpreter-mode-alist '("sclang" . sclang-mode))
 
 (add-hook 'sclang-library-startup-hook 'sclang-document-library-startup-hook-function)
@@ -706,5 +702,4 @@ Returns the column to indent to."
 (add-hook 'change-major-mode-hook 'sclang-document-change-major-mode-hook-function)
 
 (provide 'sclang-mode)
-
-;; EOF
+;;; sclang-mode ends here


### PR DESCRIPTION
This is a [recommended](https://www.gnu.org/software/emacs/manual/html_node/elisp/Derived-Modes.html#Derived-Modes) (and simpler) method for creating major modes.
`sclang-mode` now is a child of `prog-mode`. 

Practically this means that user settings for `prog-mode` will now apply to `sclang-mode` as well.

I've also change `auto-mode-alist` to look more like other modes are using it nowdays.