### PR TITLE
Add support for completion-at-point-functions and company-mode

### DIFF
--- a/el/sclang-mode.el
+++ b/el/sclang-mode.el
@@ -686,7 +686,10 @@ Returns the column to indent to."
   (add-hook 'completion-at-point-functions
             #'sclang-completion-at-point nil 'local)
   (when (fboundp 'company-mode)
-    (add-to-list 'company-backends 'company-capf)))
+    (declare 'company-backends)
+    (add-to-list 'company-backends 'company-capf))
+
+  (run-hooks 'sclang-mode-hook))
 
 ;; =====================================================================
 ;; module initialization


### PR DESCRIPTION
Completion isn't context aware, i.e. it will give you a list of all known methods for your `Class.`, but I think it's still more useful then `sclang-complete-symbol`.