### PR TITLE
Allow use of pw-jack with custom variable

### DIFF
--- a/el/sclang-interp.el
+++ b/el/sclang-interp.el
@@ -184,6 +184,11 @@ If EOB-P is non-nil, positions cursor at end of buffer."
   :version "21.3"
   :type 'boolean)
 
+(defcustom sclang-use-pw-jack nil
+  "Use the pw-jack command to launch `sclang-program` to use PipeWire's jack implementation."
+  :group 'sclang-options
+  :version "21.3"
+  :type 'boolean)
 ;; =====================================================================
 ;; helper functions
 ;; =====================================================================
@@ -284,6 +289,8 @@ If EOB-P is non-nil, positions cursor at end of buffer."
 (defun sclang-make-options ()
   (let ((default-directory ""))
     (nconc
+     (when sclang-use-pw-jack
+       (list sclang-program))
      (when (and sclang-runtime-directory
 		(file-directory-p sclang-runtime-directory))
        (list "-d" (expand-file-name sclang-runtime-directory)))
@@ -314,7 +321,9 @@ If EOB-P is non-nil, positions cursor at end of buffer."
   (let ((process-connection-type nil))
     (let ((proc (apply 'start-process
 		       sclang-process sclang-post-buffer
-		       sclang-program (sclang-make-options))))
+		       (if sclang-use-pw-jack "pw-jack"
+			 sclang-program)
+		       (sclang-make-options))))
       (set-process-sentinel proc 'sclang-process-sentinel)
       (set-process-filter proc 'sclang-process-filter)
       (set-process-coding-system proc 'mule-utf-8 'mule-utf-8)


### PR DESCRIPTION
I'm using PipeWire under Linux and need to use `pw-jack` to start `sclang` to ensure that we're using PipeWire's implementation of Jack instead of Jack's own implementation.

This patch adds the custom variable

`sclang-use-pw-jack`. When it's non-nil- `sclang-start` will load `pw-jack` instead of `sclang-program` and instead add `sclang-program` to the first argument generated by `sclang-make-options`

Let me know what you think :) 