### PR TITLE
Fixes syntax highlighting

### DIFF
--- a/el/sclang-mode.el
+++ b/el/sclang-mode.el
@@ -255,12 +255,12 @@
     (while continue
       (setq res (re-search-forward regexp limit t))
       (if (or (null res) (null sclang-class-list))
-	   (setq continue nil)
-	(let ((word (current-word 'strict 'really-word)))
-	  (if (null word)
-	      (setq res nil continue nil)
-	    (when (cl-position word sclang-class-list :test 'equal)
-	      (setq continue nil))))))
+        (setq continue nil)
+        (let ((word (current-word 'strict 'really-word)))
+          (if (null word)
+            (setq res nil continue nil)
+            (when (cl-position word sclang-class-list :test 'equal)
+              (setq continue nil))))))
     res))
 
 (defun sclang-set-font-lock-keywords ()

--- a/el/sclang-mode.el
+++ b/el/sclang-mode.el
@@ -255,12 +255,12 @@
     (while continue
       (setq res (re-search-forward regexp limit t))
       (if (or (null res) (null sclang-class-list))
-          (setq continue nil)
-        (let ((thing (thing-at-point 'word)))
-          (if (null thing)
-              (setq res nil continue nil)
-            (when (cl-position (substring-no-properties thing) sclang-class-list :test 'equal)
-              (setq continue nil))))))
+	   (setq continue nil)
+	(let ((word (current-word 'strict 'really-word)))
+	  (if (null word)
+	      (setq res nil continue nil)
+	    (when (cl-position word sclang-class-list :test 'equal)
+	      (setq continue nil))))))
     res))
 
 (defun sclang-set-font-lock-keywords ()


### PR DESCRIPTION
This resolves #67 .

It appears that using `thing-at-point`, when looking at the returned properties of the `thing` would include that the `thing` was already `fontified`. This effectively would turn off any syntax highlighting, including the naive highlighting before `sclang-class-list` is loaded. Switching to another function, `current-word`, appears to have the correct behavior: when typing out a class, it is not highlighted until the word matches a class in `sclang-class-list`. For example, starting to type `SinOs` results in plain text, but upon finishing with `SinOsc`, it becomes highlighted.